### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run HyperExecute Selenium Gradle TestNG Tests on TestMu AI (Formerly LambdaTest)
+﻿# Run HyperExecute Selenium Gradle TestNG Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,7 +17,7 @@ With TestMu AI (Formerly LambdaTest), you can run Selenium Gradle TestNG tests a
 
 ### Prerequisites
 
-- [Java](https://www.oracle.com/java/technologies/downloads/) and [Gradle](https://gradle.org/install/) installed
+- Java and Gradle installed
 - HyperExecute CLI — download the binary for your OS:
 
 | Operating System | CLI Download Link |
@@ -26,7 +26,7 @@ With TestMu AI (Formerly LambdaTest), you can run Selenium Gradle TestNG tests a
 | Windows | https://downloads.lambdatest.com/hyperexecute/windows/hyperexecute.exe |
 | macOS | https://downloads.lambdatest.com/hyperexecute/darwin/hyperexecute |
 
-- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+- A TestMu AI (Formerly LambdaTest) account — sign up here
 
 ### Setup
 
@@ -104,7 +104,7 @@ gradle clean test
 gradle clean smokeTests
 ```
 
-Visit the [HyperExecute Dashboard](https://hyperexecute.lambdatest.com/hyperexecute) to monitor your job status and view detailed execution logs.
+Visit the HyperExecute Dashboard to monitor your job status and view detailed execution logs.
 
 ### Local testing with TestMu AI Tunnel
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.